### PR TITLE
Remove parentheses from runCatching docs title

### DIFF
--- a/docs/api/core/kotlin-stdlib/kotlin/run-catching.md
+++ b/docs/api/core/kotlin-stdlib/kotlin/run-catching.md
@@ -1,4 +1,4 @@
-# runCatching()
+# runCatching
 
 ```ts
 function runCatching<T>(block: () => T): Result<T>


### PR DESCRIPTION
### Docs

- Remove parentheses from `runCatching()` document title.